### PR TITLE
new pc migration and transaction type fixx

### DIFF
--- a/BudgetTracker.DataAccessLayer/BudgetTrackerContext.cs
+++ b/BudgetTracker.DataAccessLayer/BudgetTrackerContext.cs
@@ -38,6 +38,11 @@ namespace BudgetTracker.DataAccessLayer
                 .WithMany(p => p.Transactions) 
                 .HasForeignKey(t => t.PaymentMethodId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            // Transaction - Amount: Precision ve Scale ayarı
+            modelBuilder.Entity<Transaction>()
+                .Property(t => t.Amount)
+                .HasPrecision(18, 2); // 18 basamak, 2 ondalık basamak
         }
     }
 }

--- a/BudgetTracker.DataAccessLayer/Migrations/20241216191132_FixTransactionAmountPrecision.Designer.cs
+++ b/BudgetTracker.DataAccessLayer/Migrations/20241216191132_FixTransactionAmountPrecision.Designer.cs
@@ -4,6 +4,7 @@ using BudgetTracker.DataAccessLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BudgetTracker.DataAccessLayer.Migrations
 {
     [DbContext(typeof(BudgetTrackerContext))]
-    partial class BudgetTrackerContextModelSnapshot : ModelSnapshot
+    [Migration("20241216191132_FixTransactionAmountPrecision")]
+    partial class FixTransactionAmountPrecision
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BudgetTracker.DataAccessLayer/Migrations/20241216191132_FixTransactionAmountPrecision.cs
+++ b/BudgetTracker.DataAccessLayer/Migrations/20241216191132_FixTransactionAmountPrecision.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BudgetTracker.DataAccessLayer.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixTransactionAmountPrecision : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/BudgetTracker.DataAccessLayer/UserRepository.cs
+++ b/BudgetTracker.DataAccessLayer/UserRepository.cs
@@ -7,7 +7,7 @@ namespace BudgetTracker.DataAccessLayer
     public class UserRepository : GenericRepository<User>
     {
         public UserRepository(BudgetTrackerContext context) : base(context) { }
-        
+        //test
 
     }
 }


### PR DESCRIPTION
Add precision and scale to Transaction.Amount property

Introduce precision (18) and scale (2) for the `Amount` property in the `Transaction` entity within `BudgetTrackerContext`. Added a new migration class `20241216191132_FixTransactionAmountPrecision` with empty `Up` and `Down` methods. Updated `BudgetTrackerContextModelSnapshot` and generated `20241216191132_FixTransactionAmountPrecision.Designer.cs` to reflect these changes.